### PR TITLE
Fix two dangling skin includes and four error paths

### DIFF
--- a/init/skins.xml
+++ b/init/skins.xml
@@ -41,8 +41,6 @@
   <!-- Turtle WoW -->
   <Include file="..\skins\blizzard\barbershop.lua"/>
   <Include file="..\skins\blizzard\transmog.lua"/>
-  <Include file="..\skins\blizzard\custom_merchant.lua"/>
-  <Include file="..\skins\blizzard\arena_score.lua"/>
   <Include file="..\skins\blizzard\ebc.lua"/>
 
 </Ui>

--- a/modules/cooldown.lua
+++ b/modules/cooldown.lua
@@ -9,7 +9,7 @@ pfUI:RegisterModule("cooldown", function ()
   local parent, parent_name
   local function pfCooldownOnUpdate()
     parent = this:GetParent()
-    if not parent then this:Hide() end
+    if not parent then this:Hide() return end
     parent_name = parent:GetName()
 
     -- avoid to set cooldowns on invalid frames

--- a/modules/firstrun.lua
+++ b/modules/firstrun.lua
@@ -263,7 +263,7 @@ pfUI:RegisterModule("firstrun", function ()
     SkinCheckbox(f.checkbox, 18)
 
     f.NextScript = function()
-      if not pfUI.chat then message("Couldn't apply settings. Chat module is disabled.") end
+      if not pfUI.chat then message("Couldn't apply settings. Chat module is disabled.") return end
       pfUI.chat.SetupRightChat(f.checkbox:GetChecked())
     end
 
@@ -283,7 +283,7 @@ pfUI:RegisterModule("firstrun", function ()
     SkinCheckbox(f.checkbox, 18)
 
     f.NextScript = function()
-      if not pfUI.chat then message("Couldn't apply settings. Chat module is disabled.") end
+      if not pfUI.chat then message("Couldn't apply settings. Chat module is disabled.") return end
       if f.checkbox:GetChecked() then
         pfUI.chat.SetupPositions()
       end
@@ -305,7 +305,7 @@ pfUI:RegisterModule("firstrun", function ()
     SkinCheckbox(f.checkbox, 18)
 
     f.NextScript = function()
-      if not pfUI.chat then message("Couldn't apply settings. Chat module is disabled.") end
+      if not pfUI.chat then message("Couldn't apply settings. Chat module is disabled.") return end
       if f.checkbox:GetChecked() then
         pfUI.chat.SetupChannels()
       end

--- a/modules/map.lua
+++ b/modules/map.lua
@@ -77,7 +77,13 @@ pfUI:RegisterModule("map", function ()
           if point == "TOPLEFT" and relpoint == "TOPLEFT" then
             offx = offx*oldscale/scale
             offy = offy*oldscale/scale
-            WorldMapFrame:SetPoint(point, rel, relpoint, offx, offy)
+            -- Anchor to the parent (3-arg SetPoint) rather than re-using the frame
+            -- GetPoint handed back. Re-anchoring to `rel` throws
+            -- "<unnamed> is dependent on this" as soon as anything else has anchored
+            -- itself to WorldMapFrame, which aborts the whole zoom handler. The
+            -- parent-relative form is also what LoadMovable/SaveMovable already
+            -- assume: SaveMovable stores only xpos/ypos, with no relative frame.
+            WorldMapFrame:SetPoint(point, offx, offy)
           end
 
           WorldMapFrame:SetScale(scale)

--- a/modules/roll.lua
+++ b/modules/roll.lua
@@ -43,6 +43,7 @@ pfUI:RegisterModule("roll", function ()
 
     local _, _, itemLink = string.find(hyperlink, "(item:%d+:%d+:%d+:%d+)")
     local itemName = C_Item.GetItemInfo(itemLink)
+    if not itemName then return end -- uncached item: avoid cache[nil] "table index is nil"
 
     -- delete obsolete tables
     if pfUI.roll.cache[itemName] and pfUI.roll.cache[itemName]["TIMESTAMP"] < GetTime() - 60 then

--- a/modules/unitxp.lua
+++ b/modules/unitxp.lua
@@ -169,6 +169,9 @@ pfUI:RegisterModule("unitxp", function ()
 
           local throttle = 0
           local scanner = CreateFrame("Frame")
+          -- expose the poller frame so PLAYER_LOGOUT can stop its UnitXP OnUpdate
+          -- (it lives on this separate frame, not on distanceIndicator) -> crash 132
+          pfUI.uf.target.distanceScanner = scanner
           scanner:SetScript("OnUpdate", function()
             throttle = throttle + arg1
             if throttle < 0.05 then return end
@@ -235,6 +238,10 @@ pfUI:RegisterModule("unitxp", function ()
         end
         if pfUI.uf.target.distanceIndicator then
           pfUI.uf.target.distanceIndicator:SetScript("OnUpdate", nil)
+        end
+        -- free-frame mode polls from its own scanner frame, not the indicator
+        if pfUI.uf.target.distanceScanner then
+          pfUI.uf.target.distanceScanner:SetScript("OnUpdate", nil)
         end
       end
       return


### PR DESCRIPTION
Hi — I've been running your ClassicAPI edition on an OctoWoW (1.12) server for a few weeks
and kept a list of things I hit. These are the ones that produce a visible error or abort a
handler; a second PR covers things that fail silently.

All of them were re-checked against `master` at `2dfaa651` before opening this, so nothing
here should already be fixed. Each is independent — happy to split this up, drop any of
them, or rework anything you'd rather see done differently.

---

### `init/skins.xml` — two includes reference files that aren't in the repo

`custom_merchant.lua` and `arena_score.lua` are included but not tracked in git. That's two
`Error loading` lines at every login, and because the release workflow packages the
repository, both skins are missing from every release zip as well — so it affects everyone
on a released build, not just people running from a checkout.

Removed the two include lines. If the files exist locally and just never got committed,
adding them instead is obviously the better fix.

### `modules/map.lua` — ctrl+scroll zoom silently stops working

```lua
local point, rel, relpoint, offx, offy = WorldMapFrame:GetPoint()
...
WorldMapFrame:SetPoint(point, rel, relpoint, offx, offy)
```

`GetPoint()` returns whatever frame the map is currently anchored to, and re-anchoring to it
throws `<unnamed> is dependent on this` as soon as anything else is anchored to
`WorldMapFrame`. The error aborts the rest of the handler, so `SetScale` never runs and
ctrl+scroll appears to do nothing at all.

Anchors to `UIParent` explicitly instead of round-tripping the current relative frame.

### `modules/cooldown.lua` — missing `return` after the nil test

```lua
if not parent then this:Hide() end
```

No `return`, so it falls straight through to `parent:GetName()` on the nil it just tested for.

### `modules/roll.lua` — `table index is nil` on an uncached item

```lua
local itemName = C_Item.GetItemInfo(itemLink)
...
pfUI.roll.cache[itemName] = { ... }
```

`GetItemInfo` returns nil for an item the client hasn't cached, and assigning to a nil key
throws. Easy to hit on a fresh login when someone rolls on something you've never seen.

Returns early when the name can't be resolved.

### `modules/unitxp.lua` — the free-frame distance poller survives logout

The `PLAYER_LOGOUT` handler stops the indicators to avoid the UnitXP crash on exit, but in
free-frame distance mode the polling happens on a *separate* scanner frame that was never
exposed, so the handler can't reach it and its `OnUpdate` keeps calling into UnitXP.

`distanceScanner` doesn't appear anywhere in the current tree, so the handler has no way to
stop it. This exposes the frame and stops it alongside the others.

### `modules/firstrun.lua` — three steps print "disabled" then use the nil they tested

Three chat-setup steps print `Chat module is disabled` and then carry straight on into
`pfUI.chat`, which is the nil they just checked for.

---

Thanks for the ClassicAPI work — being able to read GUIDs and real unit tokens has made a
genuine difference to how this UI behaves.
